### PR TITLE
rosidl_cli: Add type description support

### DIFF
--- a/rosidl_cli/rosidl_cli/cli.py
+++ b/rosidl_cli/rosidl_cli/cli.py
@@ -16,6 +16,7 @@ import argparse
 import signal
 
 from rosidl_cli.command.generate import GenerateCommand
+from rosidl_cli.command.hash import HashCommand
 from rosidl_cli.command.translate import TranslateCommand
 from rosidl_cli.common import get_first_line_doc
 
@@ -74,7 +75,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
-    commands = [GenerateCommand(), TranslateCommand()]
+    commands = [GenerateCommand(), TranslateCommand(), HashCommand()]
 
     # add arguments for command extension(s)
     add_subparsers(

--- a/rosidl_cli/rosidl_cli/command/generate/__init__.py
+++ b/rosidl_cli/rosidl_cli/command/generate/__init__.py
@@ -39,8 +39,8 @@ class GenerateCommand(Command):
             dest='typesupports', action='append', default=[],
             help='Target type supports for generation.')
         parser.add_argument(
-            '-td', '--type-description', metavar='TYPE_DESCRIPTION',
-            dest='type_descriptions', action='append', default=[],
+            '-td', '--type-description-file', metavar='PATH',
+            dest='type_description_files', action='append', default=[],
             help='Target type descriptions for generation.')
         parser.add_argument(
             '-I', '--include-path', type=pathlib.Path, metavar='PATH',
@@ -62,5 +62,5 @@ class GenerateCommand(Command):
             output_path=args.output_path,
             types=args.types,
             typesupports=args.typesupports,
-            type_descriptions=args.type_descriptions
+            type_description_files=args.type_description_files
         )

--- a/rosidl_cli/rosidl_cli/command/generate/__init__.py
+++ b/rosidl_cli/rosidl_cli/command/generate/__init__.py
@@ -39,6 +39,10 @@ class GenerateCommand(Command):
             dest='typesupports', action='append', default=[],
             help='Target type supports for generation.')
         parser.add_argument(
+            '-td', '--type-description', metavar='TYPE_DESCRIPTION',
+            dest='type_descriptions', action='append', default=[],
+            help='Target type descriptions for generation.')
+        parser.add_argument(
             '-I', '--include-path', type=pathlib.Path, metavar='PATH',
             dest='include_paths', action='append', default=[],
             help='Paths to include dependency interface definition files from.')
@@ -57,5 +61,6 @@ class GenerateCommand(Command):
             include_paths=args.include_paths,
             output_path=args.output_path,
             types=args.types,
-            typesupports=args.typesupports
+            typesupports=args.typesupports,
+            type_descriptions=args.type_descriptions
         )

--- a/rosidl_cli/rosidl_cli/command/generate/api.py
+++ b/rosidl_cli/rosidl_cli/command/generate/api.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import os
 import pathlib
 
-from .extensions import load_type_extensions
-from .extensions import load_typesupport_extensions
+from .extensions import GenerateCommandExtension, load_type_extensions, load_typesupport_extensions
 
 
 def generate(
@@ -26,7 +26,8 @@ def generate(
     include_paths=None,
     output_path=None,
     types=None,
-    typesupports=None
+    typesupports=None,
+    type_descriptions=None
 ):
     """
     Generate source code from interface definition files.
@@ -57,6 +58,7 @@ def generate(
         source code files, defaults to the current working directory
     :param types: optional list of type representations to generate
     :param typesupports: optional list of type supports to generate
+    :param type_descriptions: Optional list of paths to type description files
     :returns: list of lists of paths to generated source code files,
         one group per type or type support extension invoked
     """
@@ -85,15 +87,32 @@ def generate(
     else:
         os.makedirs(output_path, exist_ok=True)
 
-    if len(extensions) > 1:
-        return [
+    def get_extra_kwargs(extension: GenerateCommandExtension):
+        extra_kwargs = {}
+        sig = inspect.signature(extension.generate)
+        if "type_descriptions" in sig.parameters:
+            extra_kwargs['type_descriptions'] = type_descriptions
+        return extra_kwargs
+
+    generated_files = []
+    if len(extensions) == 1:
+        extension = extensions[0]
+        extra_kwargs = get_extra_kwargs(extension)
+        generated_files.append(
             extension.generate(
                 package_name, interface_files, include_paths,
-                output_path=output_path / extension.name)
-            for extension in extensions
-        ]
-
-    return [extensions[0].generate(
-        package_name, interface_files,
-        include_paths, output_path
-    )]
+                output_path=output_path,
+                **extra_kwargs
+            )
+        )
+    else:
+        for extension in extensions:
+            extra_kwargs = get_extra_kwargs(extension)
+            generated_files.append(
+                extension.generate(
+                    package_name, interface_files, include_paths,
+                    output_path=output_path / extension.name,
+                    **extra_kwargs
+                    )
+            )
+        return generated_files

--- a/rosidl_cli/rosidl_cli/command/generate/api.py
+++ b/rosidl_cli/rosidl_cli/command/generate/api.py
@@ -87,32 +87,36 @@ def generate(
     else:
         os.makedirs(output_path, exist_ok=True)
 
-    def get_extra_kwargs(extension: GenerateCommandExtension):
-        extra_kwargs = {}
-        sig = inspect.signature(extension.generate)
-        if "type_description_files" in sig.parameters:
-            extra_kwargs['type_description_files'] = type_description_files
-        return extra_kwargs
+    def extra_kwargs(func: callable, **kwargs):
+        matched_kwargs = {}
+        signature = inspect.signature(func)
+        for name, value in kwargs.items():
+            if name in signature.parameters:
+                if signature.parameters[name].kind not in [
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD
+                ]:
+                    matched_kwargs[name] = value
+        return matched_kwargs
 
     generated_files = []
     if len(extensions) == 1:
         extension = extensions[0]
-        extra_kwargs = get_extra_kwargs(extension)
         generated_files.append(
             extension.generate(
                 package_name, interface_files, include_paths,
                 output_path=output_path,
-                **extra_kwargs
+                **extra_kwargs(extension.generate, type_description_files=type_description_files)
             )
         )
     else:
         for extension in extensions:
-            extra_kwargs = get_extra_kwargs(extension)
             generated_files.append(
                 extension.generate(
                     package_name, interface_files, include_paths,
                     output_path=output_path / extension.name,
-                    **extra_kwargs
+                    **extra_kwargs(extension.generate, type_description_files=type_description_files)
                 )
             )
         return generated_files

--- a/rosidl_cli/rosidl_cli/command/generate/api.py
+++ b/rosidl_cli/rosidl_cli/command/generate/api.py
@@ -27,7 +27,7 @@ def generate(
     output_path=None,
     types=None,
     typesupports=None,
-    type_descriptions=None
+    type_description_files=None
 ):
     """
     Generate source code from interface definition files.
@@ -58,7 +58,7 @@ def generate(
         source code files, defaults to the current working directory
     :param types: optional list of type representations to generate
     :param typesupports: optional list of type supports to generate
-    :param type_descriptions: Optional list of paths to type description files
+    :param type_description_files: Optional list of paths to type description files
     :returns: list of lists of paths to generated source code files,
         one group per type or type support extension invoked
     """
@@ -90,8 +90,8 @@ def generate(
     def get_extra_kwargs(extension: GenerateCommandExtension):
         extra_kwargs = {}
         sig = inspect.signature(extension.generate)
-        if "type_descriptions" in sig.parameters:
-            extra_kwargs['type_descriptions'] = type_descriptions
+        if "type_description_files" in sig.parameters:
+            extra_kwargs['type_description_files'] = type_description_files
         return extra_kwargs
 
     generated_files = []
@@ -113,6 +113,6 @@ def generate(
                     package_name, interface_files, include_paths,
                     output_path=output_path / extension.name,
                     **extra_kwargs
-                    )
+                )
             )
         return generated_files

--- a/rosidl_cli/rosidl_cli/command/generate/extensions.py
+++ b/rosidl_cli/rosidl_cli/command/generate/extensions.py
@@ -30,7 +30,7 @@ class GenerateCommandExtension(Extension):
         interface_files,
         include_paths,
         output_path,
-        type_descriptions=None,
+        type_description_files=None,
     ):
         """
         Generate source code.
@@ -44,7 +44,7 @@ class GenerateCommandExtension(Extension):
         :param include_paths: list of paths to include dependency interface
           definition files from.
         :param output_path: path to directory to hold generated source code files
-        :param type_descriptions: Optional list of paths to type description files
+        :param type_description_files: Optional list of paths to type description files
         :returns: list of paths to generated source files
         """
         raise NotImplementedError()

--- a/rosidl_cli/rosidl_cli/command/generate/extensions.py
+++ b/rosidl_cli/rosidl_cli/command/generate/extensions.py
@@ -29,7 +29,8 @@ class GenerateCommandExtension(Extension):
         package_name,
         interface_files,
         include_paths,
-        output_path
+        output_path,
+        type_descriptions=None,
     ):
         """
         Generate source code.
@@ -43,6 +44,7 @@ class GenerateCommandExtension(Extension):
         :param include_paths: list of paths to include dependency interface
           definition files from.
         :param output_path: path to directory to hold generated source code files
+        :param type_descriptions: Optional list of paths to type description files
         :returns: list of paths to generated source files
         """
         raise NotImplementedError()

--- a/rosidl_cli/rosidl_cli/command/hash/__init__.py
+++ b/rosidl_cli/rosidl_cli/command/hash/__init__.py
@@ -20,7 +20,7 @@ from .api import generate_type_hashes
 
 
 class HashCommand(Command):
-    """Generate the type hashes from interface definition files."""
+    """Generate type description hashes from interface definition files."""
 
     name = 'hash'
 

--- a/rosidl_cli/rosidl_cli/command/hash/__init__.py
+++ b/rosidl_cli/rosidl_cli/command/hash/__init__.py
@@ -1,0 +1,51 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command import Command
+
+from .api import generate_type_hashes
+
+
+class HashCommand(Command):
+    """Generate the type hashes from interface definition files."""
+
+    name = 'hash'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-o', '--output-path', metavar='PATH',
+            type=pathlib.Path, default=None,
+            help=('Path to directory to hold generated '
+                  "source code files. Defaults to '.'."))
+        parser.add_argument(
+            '-I', '--include-path', type=pathlib.Path, metavar='PATH',
+            dest='include_paths', action='append', default=[],
+            help='Paths to include dependency interface definition files from.')
+        parser.add_argument(
+            'package_name', help='Name of the package to generate code for')
+        parser.add_argument(
+            'interface_files', metavar='interface_file', nargs='+',
+            help=('Relative path to an interface definition file. '
+                  "If prefixed by another path followed by a colon ':', "
+                  'path resolution is performed against such path.'))
+
+    def main(self, *, args):
+        generate_type_hashes(
+            package_name=args.package_name,
+            interface_files=args.interface_files,
+            include_paths=args.include_paths,
+            output_path=args.output_path,
+        )

--- a/rosidl_cli/rosidl_cli/command/hash/api.py
+++ b/rosidl_cli/rosidl_cli/command/hash/api.py
@@ -56,14 +56,16 @@ def generate_type_hashes(
     else:
         pathlib.Path.mkdir(output_path, parents=True, exist_ok=True)
 
-    return [
-        extension.generate_type_hashes(
+    generated_hashes = []
+    for extension in extensions:
+        generated_hashes.extend(extension.generate_type_hashes(
             package_name,
             interface_files,
             include_paths,
             output_path=output_path,
-        )
-        for extension in extensions]
+        ))
+
+    return generated_hashes
 
 
 

--- a/rosidl_cli/rosidl_cli/command/hash/api.py
+++ b/rosidl_cli/rosidl_cli/command/hash/api.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from .extensions import load_hash_extensions
+
+
+def generate_type_hashes(
+    *,
+    package_name,
+    interface_files,
+    include_paths=None,
+    output_path=None,
+):
+    """
+    Generate type hashes from interface definition files.
+
+    To do so, this function leverages type description hash generation support
+    as provided by third-party package extensions.
+
+    Each path to an interface definition file is a relative path optionally
+    prefixed by another path followed by a colon ':', against which the first
+    relative path is to be resolved.
+
+    The directory structure that these relative paths exhibit will be replicated
+    on output (as opposed to the prefix path, which will be ignored).
+
+    :param package_name: name of the package to generate hashes for
+    :param interface_files: list of paths to interface definition files
+    :param include_paths: optional list of paths to include dependency
+        interface definition files from
+    :param output_path: optional path to directory to hold generated
+        source code files, defaults to the current working directory
+    :returns: list of lists of paths to generated hashed json files,
+        one group per type or type support extension invoked
+    """
+    extensions = []
+    extensions.extend(load_hash_extensions())
+
+    if include_paths is None:
+        include_paths = []
+    if output_path is None:
+        output_path = pathlib.Path.cwd()
+    else:
+        pathlib.Path.mkdir(output_path, parents=True, exist_ok=True)
+
+    return [
+        extension.generate_type_hashes(
+            package_name,
+            interface_files,
+            include_paths,
+            output_path=output_path,
+        )
+        for extension in extensions]
+
+
+

--- a/rosidl_cli/rosidl_cli/command/hash/extensions.py
+++ b/rosidl_cli/rosidl_cli/command/hash/extensions.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_cli.extensions import Extension
+from rosidl_cli.extensions import load_extensions
+
+
+class HashCommandExtension(Extension):
+    """
+    The extension point for source code generation.
+
+    The following methods must be defined:
+    * `generate_type_hashes`
+    """
+
+    def generate_type_hashes(
+        self,
+        package_name,
+        interface_files,
+        include_paths,
+        output_path,
+    ):
+        """
+        Generate type hashes from interface definition files.
+
+        Paths to interface definition files are relative paths optionally
+        prefixed by an absolute path followed by a colon ':', in which case
+        path resolution is to be performed against that absolute path.
+
+        :param package_name: name of the package to generate source code for
+        :param interface_files: list of paths to interface definition files
+        :param include_paths: list of paths to include dependency interface
+          definition files from.
+        :param output_path: path to directory to hold generated source code files
+        :returns: list of paths to generated source files
+        """
+        raise NotImplementedError()
+
+
+def load_hash_extensions(**kwargs):
+    """Load extensions for type hash generation."""
+    return load_extensions(
+        'rosidl_cli.command.hash.extensions', **kwargs
+    )

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -87,18 +87,27 @@ def idl_tuples_from_interface_files(interface_files):
     return idl_tuples
 
 
-def type_description_tuples_from_interface_files(interface_files, output_path):
-    """Express ROS interface type description hash file paths as type_description tuples.
-
-    A type_description tuple as defined in rosidl_generator_type_description_generate_interfaces.cmake.
+def build_type_description_tuples(idl_interface_files, type_description_files):
     """
-    type_description_tuples = []
-    for path in interface_files:
-        _, path = interface_path_as_tuple(path)
-        filedir = path.parent.name
-        type_description_tuples.append(f'{path.as_posix()}:{output_path}/{filedir}/{path.stem}.json')
-    return type_description_tuples
+    Create type description tuples from IDL interface files and type descriptions.
 
+    :param idl_interface_files: List of IDL interface files either with or without prefix
+    :param type_description_files: List of type description files
+    :return: List of type description tuples of the form 'idl_file_path:type_description_file'
+    """
+    def get_type_description_file(idl_file, type_description_files):
+        for type_description_file in type_description_files:
+            if pathlib.Path(idl_file).stem == pathlib.Path(type_description_file).stem:
+                return type_description_file
+
+    type_description_tuples = []
+    for idl_file in idl_interface_files:
+        type_description_file = get_type_description_file(idl_file, type_description_files)
+        assert type_description_file is not None, \
+            f"Type description file not found for {idl_file}"
+        _, path = interface_path_as_tuple(idl_file)
+        type_description_tuples.append(f"{path}:{type_description_file}")
+    return type_description_tuples
 
 @contextlib.contextmanager
 def legacy_generator_arguments_file(
@@ -108,7 +117,7 @@ def legacy_generator_arguments_file(
     include_paths,
     templates_path,
     output_path,
-    **kwargs
+    extra_args=None
 ):
     """
     Generate a temporary rosidl generator arguments file.
@@ -123,7 +132,7 @@ def legacy_generator_arguments_file(
     :param templates_path: Path to the templates directory for the
       generator script this arguments are for
     :param output_path: Path to the output directory for generated code
-    :param kwargs: Additional arguments to be included in the generator
+    :param extra_args: Dict of additional arguments to be included in the generator
       arguments file, they'll be included as they are passed without any processing
     """
 
@@ -137,7 +146,7 @@ def legacy_generator_arguments_file(
     arguments['target_dependencies'] = []
     # NOTE(frneer): Add additional arguments directly to the output file.
     # This allows extending the generator argument file externally
-    arguments.update(kwargs)
+    arguments.update(extra_args or {})
 
     # NOTE(hidmic): named temporary files cannot be opened twice on Windows,
     # so close it and manually remove it when leaving the context

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -122,17 +122,36 @@ def ros_interface_file_from_idl(idl_file):
 
 
 @contextlib.contextmanager
-def legacy_generator_arguments_file(
-    *,
-    package_name,
-    interface_files,
-    include_paths,
-    templates_path,
-    output_path,
-    extra_args=None
+def generator_arguments_file(**kwargs):
+    """
+    Create a temporary file containing generator arguments.
+
+    :param kwargs: Generator arguments to be written to the file.
+    :yields: Path to the temporary file containing the generator arguments.
+    """
+    # NOTE(hidmic): named temporary files cannot be opened twice on Windows,
+    # so close it and manually remove it when leaving the context
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write(json.dumps(kwargs))
+    path_to_file = os.path.abspath(tmp.name)
+    try:
+        yield path_to_file
+    finally:
+        try:
+            os.unlink(path_to_file)
+        except FileNotFoundError:
+            pass
+
+def legacy_generator_arguments(
+        *,
+        package_name,
+        interface_files,
+        include_paths,
+        templates_path,
+        output_path,
 ):
     """
-    Generate a temporary rosidl generator arguments file.
+    Returns a dict containing the generator arguments for the legacy ROSIDL generator.
 
     :param package_name: Name of the ROS package for which to generate code
     :param interface_files: Relative paths to ROS interface definition files,
@@ -144,10 +163,7 @@ def legacy_generator_arguments_file(
     :param templates_path: Path to the templates directory for the
       generator script this arguments are for
     :param output_path: Path to the output directory for generated code
-    :param extra_args: Dict of additional arguments to be included in the generator
-      arguments file, they'll be included as they are passed without any processing
     """
-
     arguments = {}
     arguments['package_name'] = package_name
     arguments['output_dir'] = os.path.abspath(output_path)
@@ -156,22 +172,35 @@ def legacy_generator_arguments_file(
     arguments['ros_interface_dependencies'] = dependencies_from_include_paths(include_paths)
     # TODO(hidmic): re-enable output file caching
     arguments['target_dependencies'] = []
-    # NOTE(frneer): Add additional arguments directly to the output file.
-    # This allows extending the generator argument file externally
-    arguments.update(extra_args or {})
 
-    # NOTE(hidmic): named temporary files cannot be opened twice on Windows,
-    # so close it and manually remove it when leaving the context
-    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
-        tmp.write(json.dumps(arguments))
-    path_to_file = os.path.abspath(tmp.name)
-    try:
-        yield path_to_file
-    finally:
-        try:
-            os.unlink(path_to_file)
-        except FileNotFoundError:
-            pass
+    return arguments
+
+@contextlib.contextmanager
+def legacy_generator_arguments_file(
+    *,
+    package_name,
+    interface_files,
+    include_paths,
+    templates_path,
+    output_path
+):
+    """
+    Create a temporary file containing legacy arguments only.
+
+    This context manager is kept for backwards compatibility only, use
+    `generator_arguments_file` instead.
+    """
+
+    with generator_arguments_file(
+        **legacy_generator_arguments(
+            package_name=package_name,
+            interface_files=interface_files,
+            include_paths=include_paths,
+            templates_path=templates_path,
+            output_path=output_path
+        )
+    ) as path_to_arguments_file:
+        yield path_to_arguments_file
 
 
 def generate_visibility_control_file(

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -103,8 +103,8 @@ def build_type_description_tuples(idl_interface_files, type_description_files):
     type_description_tuples = []
     for idl_file in idl_interface_files:
         type_description_file = get_type_description_file(idl_file, type_description_files)
-        assert type_description_file is not None, \
-            f"Type description file not found for {idl_file}"
+        if type_description_file is None:
+            raise ValueError(f"Type description file not found for {idl_file}")
         _, path = interface_path_as_tuple(idl_file)
         type_description_tuples.append(f"{path}:{type_description_file}")
     return type_description_tuples

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -87,6 +87,19 @@ def idl_tuples_from_interface_files(interface_files):
     return idl_tuples
 
 
+def type_description_tuples_from_interface_files(interface_files, output_path):
+    """Express ROS interface type description hash file paths as type_description tuples.
+
+    A type_description tuple as defined in rosidl_generator_type_description_generate_interfaces.cmake.
+    """
+    type_description_tuples = []
+    for path in interface_files:
+        _, path = interface_path_as_tuple(path)
+        filedir = path.parent.name
+        type_description_tuples.append(f'{path.as_posix()}:{output_path}/{filedir}/{path.stem}.json')
+    return type_description_tuples
+
+
 @contextlib.contextmanager
 def legacy_generator_arguments_file(
     *,
@@ -94,7 +107,8 @@ def legacy_generator_arguments_file(
     interface_files,
     include_paths,
     templates_path,
-    output_path
+    output_path,
+    **kwargs
 ):
     """
     Generate a temporary rosidl generator arguments file.
@@ -109,23 +123,26 @@ def legacy_generator_arguments_file(
     :param templates_path: Path to the templates directory for the
       generator script this arguments are for
     :param output_path: Path to the output directory for generated code
+    :param kwargs: Additional arguments to be included in the generator
+      arguments file, they'll be included as they are passed without any processing
     """
-    idl_tuples = idl_tuples_from_interface_files(interface_files)
-    interface_dependencies = dependencies_from_include_paths(include_paths)
-    output_path = os.path.abspath(output_path)
-    templates_path = os.path.abspath(templates_path)
+
+    arguments = {}
+    arguments['package_name'] = package_name
+    arguments['output_dir'] = os.path.abspath(output_path)
+    arguments['template_dir'] = os.path.abspath(templates_path)
+    arguments['idl_tuples'] = idl_tuples_from_interface_files(interface_files)
+    arguments['ros_interface_dependencies'] = dependencies_from_include_paths(include_paths)
+    # TODO(hidmic): re-enable output file caching
+    arguments['target_dependencies'] = []
+    # NOTE(frneer): Add additional arguments directly to the output file.
+    # This allows extending the generator argument file externally
+    arguments.update(kwargs)
+
     # NOTE(hidmic): named temporary files cannot be opened twice on Windows,
     # so close it and manually remove it when leaving the context
     with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
-        tmp.write(json.dumps({
-            'package_name': package_name,
-            'output_dir': output_path,
-            'template_dir': templates_path,
-            'idl_tuples': idl_tuples,
-            'ros_interface_dependencies': interface_dependencies,
-            # TODO(hidmic): re-enable output file caching
-            'target_dependencies': []
-        }))
+        tmp.write(json.dumps(arguments))
     path_to_file = os.path.abspath(tmp.name)
     try:
         yield path_to_file

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -189,7 +189,7 @@ def generate_visibility_control_file(
     with open(output_path, 'w') as fd:
         fd.write(content)
 
-def split_interface_files(interface_files):
+def split_idl_interface_files(interface_files):
     """Split interface files into IDL and non-IDL files."""
     idl_interface_files = []
     non_idl_interface_files = []

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -109,6 +109,18 @@ def build_type_description_tuples(idl_interface_files, type_description_files):
         type_description_tuples.append(f"{path}:{type_description_file}")
     return type_description_tuples
 
+def ros_interface_file_from_idl(idl_file):
+    """
+    Returns the absolute path of the ROS interface file generated from the given IDL file.
+
+    :param idl_file: The IDL file to generate the ROS interface file from. Can be prefix:relative/path/to/file.idl
+        or relative/path/to/file.idl
+    :return: The absolute path of the ROS interface file generated from the given IDL file.
+    """
+    prefix, path = interface_path_as_tuple(idl_file)
+    return (prefix / path).absolute()
+
+
 @contextlib.contextmanager
 def legacy_generator_arguments_file(
     *,

--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -179,3 +179,14 @@ def generate_visibility_control_file(
 
     with open(output_path, 'w') as fd:
         fd.write(content)
+
+def split_interface_files(interface_files):
+    """Split interface files into IDL and non-IDL files."""
+    idl_interface_files = []
+    non_idl_interface_files = []
+    for path in interface_files:
+        if not path.endswith('.idl'):
+            non_idl_interface_files.append(path)
+        else:
+            idl_interface_files.append(path)
+    return idl_interface_files, non_idl_interface_files

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -19,7 +19,8 @@ from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import (
     build_type_description_tuples,
     generate_visibility_control_file,
-    legacy_generator_arguments_file,
+    generator_arguments_file,
+    legacy_generator_arguments,
     ros_interface_file_from_idl,
     split_idl_interface_files
 )
@@ -84,16 +85,16 @@ class GenerateC(GenerateCommandExtension):
 
 
         # Generate code
-        with legacy_generator_arguments_file(
-            package_name=package_name,
-            interface_files=idl_interface_files,
-            include_paths=include_paths,
-            templates_path=templates_path,
-            output_path=output_path,
-            extra_args = {
-                "type_description_tuples": type_description_tuples,
-                "ros_interface_files": ros_interface_files
-            }
+        with generator_arguments_file(
+            **legacy_generator_arguments(
+                package_name=package_name,
+                interface_files=idl_interface_files,
+                include_paths=include_paths,
+                templates_path=templates_path,
+                output_path=output_path,
+            ),
+            type_description_tuples=type_description_tuples,
+            ros_interface_files=ros_interface_files
         ) as path_to_arguments_file:
             generated_files.extend(generate_c(path_to_arguments_file))
 

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -20,8 +20,8 @@ from rosidl_cli.command.helpers import (
     build_type_description_tuples,
     generate_visibility_control_file,
     legacy_generator_arguments_file,
-    split_idl_interface_files,
-    interface_path_as_tuple
+    ros_interface_file_from_idl,
+    split_idl_interface_files
 )
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
@@ -79,16 +79,6 @@ class GenerateC(GenerateCommandExtension):
         )
         generated_files.append(visibility_control_file_path)
 
-        def ros_interface_file_from_idl(idl_file):
-            """
-            Return the absolute path of the ROS interface file generated from the given IDL file.
-
-            :param idl_file: The IDL file to generate the ROS interface file from. Can be prefix:relative/path/to/file.idl
-                or relative/path/to/file.idl
-            :return: The absolute path of the ROS interface file generated from the given IDL file.
-            """
-            _, path = interface_path_as_tuple(idl_file)
-            return path.absolute()
 
         ros_interface_files = [str(ros_interface_file_from_idl(idl_file)) for idl_file in idl_interface_files]
 

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -17,10 +17,11 @@ import pathlib
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import (
+    build_type_description_tuples,
     generate_visibility_control_file,
     legacy_generator_arguments_file,
     split_interface_files,
-    type_description_tuples_from_interface_files
+    interface_path_as_tuple
 )
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
@@ -36,7 +37,7 @@ class GenerateC(GenerateCommandExtension):
         interface_files,
         include_paths,
         output_path,
-        type_descriptions=None
+        type_description_files=None
     ):
         generated_files = []
 
@@ -55,15 +56,15 @@ class GenerateC(GenerateCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
-        if not type_descriptions:
-            type_descriptions = generate_type_hashes(
+        if not type_description_files:
+            type_description_files = generate_type_hashes(
                 package_name=package_name,
                 interface_files=idl_interface_files,
                 include_paths=include_paths,
                 output_path=output_path
             )
 
-        type_description_tuples = type_description_tuples_from_interface_files(interface_files, output_path)
+        type_description_tuples = build_type_description_tuples(idl_interface_files, type_description_files)
 
         # Generate visibility control file
         visibility_control_file_template_path = \
@@ -78,6 +79,20 @@ class GenerateC(GenerateCommandExtension):
         )
         generated_files.append(visibility_control_file_path)
 
+        def ros_interface_file_from_idl(idl_file):
+            """
+            Return the absolute path of the ROS interface file generated from the given IDL file.
+
+            :param idl_file: The IDL file to generate the ROS interface file from. Can be prefix:relative/path/to/file.idl
+                or relative/path/to/file.idl
+            :return: The absolute path of the ROS interface file generated from the given IDL file.
+            """
+            _, path = interface_path_as_tuple(idl_file)
+            return path.absolute()
+
+        ros_interface_files = [str(ros_interface_file_from_idl(idl_file)) for idl_file in idl_interface_files]
+
+
         # Generate code
         with legacy_generator_arguments_file(
             package_name=package_name,
@@ -85,8 +100,10 @@ class GenerateC(GenerateCommandExtension):
             include_paths=include_paths,
             templates_path=templates_path,
             output_path=output_path,
-            type_description_tuples=type_description_tuples,
-            ros_interface_files=interface_files
+            extra_args = {
+                "type_description_tuples": type_description_tuples,
+                "ros_interface_files": ros_interface_files
+            }
         ) as path_to_arguments_file:
             generated_files.extend(generate_c(path_to_arguments_file))
 

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -16,9 +16,9 @@ import pathlib
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import generate_visibility_control_file
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
+    from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, type_description_tuples_from_interface_files
 from rosidl_cli.command.translate.api import translate
+from rosidl_cli.command.hash.api import generate_type_hashes
 
 from rosidl_generator_c import generate_c
 
@@ -30,7 +30,8 @@ class GenerateC(GenerateCommandExtension):
         package_name,
         interface_files,
         include_paths,
-        output_path
+        output_path,
+        type_descriptions=None
     ):
         generated_files = []
 
@@ -55,6 +56,16 @@ class GenerateC(GenerateCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
+        if not type_descriptions:
+            type_descriptions = generate_type_hashes(
+                package_name=package_name,
+                interface_files=idl_interface_files,
+                include_paths=include_paths,
+                output_path=output_path
+            )
+
+        type_description_tuples = type_description_tuples_from_interface_files(interface_files, output_path)
+
         # Generate visibility control file
         visibility_control_file_template_path = \
             templates_path / 'rosidl_generator_c__visibility_control.h.in'
@@ -74,7 +85,9 @@ class GenerateC(GenerateCommandExtension):
             interface_files=idl_interface_files,
             include_paths=include_paths,
             templates_path=templates_path,
-            output_path=output_path
+            output_path=output_path,
+            type_description_tuples=type_description_tuples,
+            ros_interface_files=interface_files
         ) as path_to_arguments_file:
             generated_files.extend(generate_c(path_to_arguments_file))
 

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -20,7 +20,7 @@ from rosidl_cli.command.helpers import (
     build_type_description_tuples,
     generate_visibility_control_file,
     legacy_generator_arguments_file,
-    split_interface_files,
+    split_idl_interface_files,
     interface_path_as_tuple
 )
 from rosidl_cli.command.translate.api import translate
@@ -46,7 +46,7 @@ class GenerateC(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
+        idl_interface_files, non_idl_interface_files = split_idl_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -16,7 +16,12 @@ import pathlib
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-    from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, type_description_tuples_from_interface_files
+from rosidl_cli.command.helpers import (
+    generate_visibility_control_file,
+    legacy_generator_arguments_file,
+    split_interface_files,
+    type_description_tuples_from_interface_files
+)
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
 
@@ -40,13 +45,7 @@ class GenerateC(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files = []
-        non_idl_interface_files = []
-        for path in interface_files:
-            if not path.endswith('.idl'):
-                non_idl_interface_files.append(path)
-            else:
-                idl_interface_files.append(path)
+        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
@@ -19,7 +19,8 @@ from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import (
     build_type_description_tuples,
     generate_visibility_control_file,
-    legacy_generator_arguments_file,
+    generator_arguments_file,
+    legacy_generator_arguments,
     split_idl_interface_files,
 )
 from rosidl_cli.command.translate.api import translate
@@ -78,14 +79,14 @@ class GenerateCpp(GenerateCommandExtension):
         generated_files.append(visibility_control_file_path)
 
         # Generate code
-        with legacy_generator_arguments_file(
-            package_name=package_name,
-            interface_files=idl_interface_files,
-            include_paths=include_paths,
-            templates_path=templates_path,
-            output_path=output_path,
-            extra_args= {
-                "type_description_tuples": type_description_tuples,
-            }
+        with generator_arguments_file(
+            **legacy_generator_arguments(
+                package_name=package_name,
+                interface_files=idl_interface_files,
+                include_paths=include_paths,
+                templates_path=templates_path,
+                output_path=output_path
+            ),
+            type_description_tuples=type_description_tuples,
         ) as path_to_arguments_file:
             return generate_cpp(path_to_arguments_file)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
@@ -17,9 +17,10 @@ import pathlib
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import (
+    build_type_description_tuples,
+    generate_visibility_control_file,
     legacy_generator_arguments_file,
     split_interface_files,
-    type_description_tuples_from_interface_files
 )
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
@@ -35,7 +36,7 @@ class GenerateCpp(GenerateCommandExtension):
         interface_files,
         include_paths,
         output_path,
-        type_descriptions=None
+        type_description_files=None
     ):
         package_share_path = \
             pathlib.Path(get_package_share_directory('rosidl_generator_cpp'))
@@ -52,14 +53,29 @@ class GenerateCpp(GenerateCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
-        if not type_descriptions:
-            generate_type_hashes(
+        if not type_description_files:
+            type_description_files = generate_type_hashes(
                 package_name=package_name,
                 interface_files=idl_interface_files,
                 include_paths=include_paths,
                 output_path=output_path
             )
-        type_description_tuples = type_description_tuples_from_interface_files(interface_files, output_path)
+
+        type_description_tuples = build_type_description_tuples(idl_interface_files, type_description_files)
+
+        generated_files = []
+        # Generate visibility control file
+        visibility_control_file_template_path = \
+            templates_path / 'rosidl_generator_cpp__visibility_control.hpp.in'
+        visibility_control_file_path = \
+            output_path / 'msg' / 'rosidl_generator_cpp__visibility_control.hpp'
+
+        generate_visibility_control_file(
+            package_name=package_name,
+            template_path=visibility_control_file_template_path,
+            output_path=visibility_control_file_path
+        )
+        generated_files.append(visibility_control_file_path)
 
         # Generate code
         with legacy_generator_arguments_file(
@@ -68,6 +84,8 @@ class GenerateCpp(GenerateCommandExtension):
             include_paths=include_paths,
             templates_path=templates_path,
             output_path=output_path,
-            type_description_tuples=type_description_tuples,
+            extra_args= {
+                "type_description_tuples": type_description_tuples,
+            }
         ) as path_to_arguments_file:
             return generate_cpp(path_to_arguments_file)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
@@ -16,8 +16,9 @@ import pathlib
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, type_description_tuples_from_interface_files
 from rosidl_cli.command.translate.api import translate
+from rosidl_cli.command.hash.api import generate_type_hashes
 
 from rosidl_generator_cpp import generate_cpp
 
@@ -29,7 +30,8 @@ class GenerateCpp(GenerateCommandExtension):
         package_name,
         interface_files,
         include_paths,
-        output_path
+        output_path,
+        type_descriptions=None
     ):
         package_share_path = \
             pathlib.Path(get_package_share_directory('rosidl_generator_cpp'))
@@ -52,12 +54,22 @@ class GenerateCpp(GenerateCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
+        if not type_descriptions:
+            generate_type_hashes(
+                package_name=package_name,
+                interface_files=idl_interface_files,
+                include_paths=include_paths,
+                output_path=output_path
+            )
+        type_description_tuples = type_description_tuples_from_interface_files(interface_files, output_path)
+
         # Generate code
         with legacy_generator_arguments_file(
             package_name=package_name,
             interface_files=idl_interface_files,
             include_paths=include_paths,
             templates_path=templates_path,
-            output_path=output_path
+            output_path=output_path,
+            type_description_tuples=type_description_tuples,
         ) as path_to_arguments_file:
             return generate_cpp(path_to_arguments_file)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
@@ -16,7 +16,11 @@ import pathlib
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file, type_description_tuples_from_interface_files
+from rosidl_cli.command.helpers import (
+    legacy_generator_arguments_file,
+    split_interface_files,
+    type_description_tuples_from_interface_files
+)
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
 
@@ -38,13 +42,7 @@ class GenerateCpp(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files = []
-        non_idl_interface_files = []
-        for path in interface_files:
-            if not path.endswith('.idl'):
-                non_idl_interface_files.append(path)
-            else:
-                idl_interface_files.append(path)
+        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/cli.py
@@ -20,7 +20,7 @@ from rosidl_cli.command.helpers import (
     build_type_description_tuples,
     generate_visibility_control_file,
     legacy_generator_arguments_file,
-    split_interface_files,
+    split_idl_interface_files,
 )
 from rosidl_cli.command.translate.api import translate
 from rosidl_cli.command.hash.api import generate_type_hashes
@@ -43,7 +43,7 @@ class GenerateCpp(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
+        idl_interface_files, non_idl_interface_files = split_idl_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
@@ -201,6 +201,7 @@ def generate_type_hash(generator_arguments_file: str) -> List[str]:
         }
         rel_path = Path(*top_type_name.split('/')[1:])
         json_path = output_dir / rel_path.with_suffix('.json')
+        json_path.parent.mkdir(parents=True, exist_ok=True)
         with json_path.open('w', encoding='utf-8') as json_file:
             json_file.write(json.dumps(json_content, indent=2))
         generated_files.append(json_path)

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -17,7 +17,12 @@ import os
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.hash.extensions import HashCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_idl_interface_files, package_name_from_interface_file_path
+from rosidl_cli.command.helpers import (
+    generator_arguments_file,
+    legacy_generator_arguments,
+    split_idl_interface_files,
+    package_name_from_interface_file_path,
+)
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_generator_type_description import generate_type_hash
@@ -61,17 +66,14 @@ class HashTypeDescription(HashCommandExtension):
         include_path_tuples = package_paths_from_include_paths(include_paths)
 
         # Generate code
-        with legacy_generator_arguments_file(
-            package_name=package_name,
-            interface_files=idl_interface_files,
-            include_paths=include_paths,
-            templates_path=templates_path,
-            output_path=output_path,
-            # NOTE(frneer): This include_paths mirrors what's done
-            # In the cmake version of generator, which uses a different format
-            # than the include_paths of this rosidl_cli
-            extra_args = {
-                "include_paths": include_path_tuples,
-            }
+        with generator_arguments_file(
+            **legacy_generator_arguments(
+                package_name=package_name,
+                interface_files=idl_interface_files,
+                include_paths=include_paths,
+                templates_path=templates_path,
+                output_path=output_path,
+            ),
+            include_paths= include_path_tuples
         ) as path_to_arguments_file:
             return generate_type_hash(path_to_arguments_file)

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -17,7 +17,7 @@ import os
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.hash.extensions import HashCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files, package_name_from_interface_file_path
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_idl_interface_files, package_name_from_interface_file_path
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_generator_type_description import generate_type_hash
@@ -35,7 +35,7 @@ class HashTypeDescription(HashCommandExtension):
             pathlib.Path(get_package_share_directory('rosidl_generator_type_description'))
         templates_path = package_share_path / 'resource'
 
-        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
+        idl_interface_files, non_idl_interface_files = split_idl_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -22,6 +22,19 @@ from rosidl_cli.command.translate.api import translate
 
 from rosidl_generator_type_description import generate_type_hash
 
+def package_paths_from_include_paths(include_paths):
+    """
+    Collect package paths, typically share paths, from include paths.
+
+    Package paths are absolute paths prefixed by the name of package followed by a colon ':'.
+    """
+    return list(
+        {
+            f'{package_name_from_interface_file_path(path)}:{path.parents[1]}'
+            for include_path in map(os.path.abspath, include_paths)
+            for path in pathlib.Path(include_path).glob('**/*.idl')
+        }
+    )
 
 class HashTypeDescription(HashCommandExtension):
     def generate_type_hashes(
@@ -44,20 +57,6 @@ class HashTypeDescription(HashCommandExtension):
                 output_format='idl',
                 output_path=output_path / 'tmp',
             ))
-
-        def package_paths_from_include_paths(include_paths):
-            """
-            Collect package paths, typically share paths, from include paths.
-
-            Package paths are absolute paths prefixed by the name of package followed by a colon ':'.
-            """
-            return list(
-                {
-                    f'{package_name_from_interface_file_path(path)}:{path.parents[1]}'
-                    for include_path in map(os.path.abspath, include_paths)
-                    for path in pathlib.Path(include_path).glob('**/*.idl')
-                }
-            )
 
         include_path_tuples = package_paths_from_include_paths(include_paths)
 

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from ament_index_python import get_package_share_directory
+from rosidl_cli.command.hash.extensions import HashCommandExtension
+from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.translate.api import translate
+
+from rosidl_generator_type_description import generate_type_hash
+
+
+class HashTypeDescription(HashCommandExtension):
+    def generate_type_hashes(
+        self,
+        package_name,
+        interface_files,
+        include_paths,
+        output_path,
+    ):
+        package_share_path = \
+            pathlib.Path(get_package_share_directory('rosidl_generator_type_description'))
+        templates_path = package_share_path / 'resource'
+
+        idl_interface_files = []
+        non_idl_interface_files = []
+        for path in interface_files:
+            if not path.endswith('.idl'):
+                non_idl_interface_files.append(path)
+            else:
+                idl_interface_files.append(path)
+        if non_idl_interface_files:
+            idl_interface_files.extend(translate(
+                package_name=package_name,
+                interface_files=non_idl_interface_files,
+                include_paths=include_paths,
+                output_format='idl',
+                output_path=output_path / 'tmp',
+            ))
+
+        # Generate code
+        with legacy_generator_arguments_file(
+            package_name=package_name,
+            interface_files=idl_interface_files,
+            include_paths=include_paths,
+            templates_path=templates_path,
+            output_path=output_path,
+        ) as path_to_arguments_file:
+            return generate_type_hash(path_to_arguments_file)

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -16,7 +16,7 @@ import pathlib
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.hash.extensions import HashCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_generator_type_description import generate_type_hash
@@ -34,13 +34,7 @@ class HashTypeDescription(HashCommandExtension):
             pathlib.Path(get_package_share_directory('rosidl_generator_type_description'))
         templates_path = package_share_path / 'resource'
 
-        idl_interface_files = []
-        non_idl_interface_files = []
-        for path in interface_files:
-            if not path.endswith('.idl'):
-                non_idl_interface_files.append(path)
-            else:
-                idl_interface_files.append(path)
+        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/cli.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import pathlib
+import os
 
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.hash.extensions import HashCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files, package_name_from_interface_file_path
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_generator_type_description import generate_type_hash
@@ -44,6 +45,22 @@ class HashTypeDescription(HashCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
+        def package_paths_from_include_paths(include_paths):
+            """
+            Collect package paths, typically share paths, from include paths.
+
+            Package paths are absolute paths prefixed by the name of package followed by a colon ':'.
+            """
+            return list(
+                {
+                    f'{package_name_from_interface_file_path(path)}:{path.parents[1]}'
+                    for include_path in map(os.path.abspath, include_paths)
+                    for path in pathlib.Path(include_path).glob('**/*.idl')
+                }
+            )
+
+        include_path_tuples = package_paths_from_include_paths(include_paths)
+
         # Generate code
         with legacy_generator_arguments_file(
             package_name=package_name,
@@ -51,5 +68,11 @@ class HashTypeDescription(HashCommandExtension):
             include_paths=include_paths,
             templates_path=templates_path,
             output_path=output_path,
+            # NOTE(frneer): This include_paths mirrors what's done
+            # In the cmake version of generator, which uses a different format
+            # than the include_paths of this rosidl_cli
+            extra_args = {
+                "include_paths": include_path_tuples,
+            }
         ) as path_to_arguments_file:
             return generate_type_hash(path_to_arguments_file)

--- a/rosidl_generator_type_description/setup.cfg
+++ b/rosidl_generator_type_description/setup.cfg
@@ -1,0 +1,3 @@
+[options.entry_points]
+rosidl_cli.command.hash.extensions =
+  type_description = rosidl_generator_type_description.cli:HashTypeDescription

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
@@ -17,7 +17,7 @@ import pathlib
 from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, split_interface_files
+from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, split_idl_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_introspection_c import generate_c
@@ -41,7 +41,7 @@ class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
+        idl_interface_files, non_idl_interface_files = split_idl_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
@@ -17,8 +17,7 @@ import pathlib
 from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import generate_visibility_control_file
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, split_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_introspection_c import generate_c
@@ -42,13 +41,7 @@ class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files = []
-        non_idl_interface_files = []
-        for path in interface_files:
-            if not path.endswith('.idl'):
-                non_idl_interface_files.append(path)
-            else:
-                idl_interface_files.append(path)
+        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
@@ -17,7 +17,7 @@ import pathlib
 from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_introspection_cpp import generate_cpp
@@ -39,13 +39,7 @@ class GenerateIntrospectionCppTypesupport(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files = []
-        non_idl_interface_files = []
-        for path in interface_files:
-            if not path.endswith('.idl'):
-                non_idl_interface_files.append(path)
-            else:
-                idl_interface_files.append(path)
+        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
@@ -17,7 +17,7 @@ import pathlib
 from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_idl_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_introspection_cpp import generate_cpp
@@ -39,7 +39,7 @@ class GenerateIntrospectionCppTypesupport(GenerateCommandExtension):
         templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
-        idl_interface_files, non_idl_interface_files = split_interface_files(interface_files)
+        idl_interface_files, non_idl_interface_files = split_idl_interface_files(interface_files)
         if non_idl_interface_files:
             idl_interface_files.extend(translate(
                 package_name=package_name,


### PR DESCRIPTION
This patch adds support for type description generation to the `rosidl_cli`. Addressing (issue 808 tag).

  - Add `hash` command to the `rosidl_cli`, which generates the `type_description` files.
  - Exposes a `type_descriptions` arg to input pre-generated `type_description` files.
  - Enable generators to create `type_descriptions` in case the user doesn't input any.

  