### PR TITLE
Simplify visibility control file generation

### DIFF
--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -152,34 +152,6 @@ def legacy_generator_arguments_file(
         except FileNotFoundError:
             pass
 
-
-def generate_visibility_control_file(
-    *,
-    package_name,
-    template_path,
-    output_path
-):
-    """
-    Generate a visibility control file from a template.
-
-    :param package_name: Name of the ROS package for which
-      to generate the file.
-    :param template_path: Path to template visibility control file.
-      May contain @PROJECT_NAME@ and @PROJECT_NAME_UPPER@ placeholders,
-      to be substituted by the package name, accordingly.
-    :param output_path: Path to visibility control file after interpolation.
-    """
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-
-    with open(template_path, 'r') as fd:
-        content = fd.read()
-
-    content = content.replace('@PROJECT_NAME@', package_name)
-    content = content.replace('@PROJECT_NAME_UPPER@', package_name.upper())
-
-    with open(output_path, 'w') as fd:
-        fd.write(content)
-
 def split_interface_files(interface_files):
     """Split interface files into IDL and non-IDL files."""
     idl_interface_files = []

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -126,18 +126,6 @@ add_custom_command(
   VERBATIM
 )
 
-# generate header to switch between export and import for a specific package
-set(_visibility_control_file
-  "${_output_path}/msg/rosidl_generator_c__visibility_control.h")
-string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
-configure_file(
-  "${rosidl_generator_c_TEMPLATE_DIR}/rosidl_generator_c__visibility_control.h.in"
-  "${_visibility_control_file}"
-  @ONLY
-)
-
-list(APPEND _generated_msg_headers "${_visibility_control_file}")
-
 set(_target_suffix "__rosidl_generator_c")
 
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${rosidl_generator_c_LIBRARY_TYPE}

--- a/rosidl_generator_c/rosidl_generator_c/cli.py
+++ b/rosidl_generator_c/rosidl_generator_c/cli.py
@@ -17,7 +17,6 @@ import pathlib
 from ament_index_python import get_package_share_directory
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import (
-    generate_visibility_control_file,
     legacy_generator_arguments_file,
     split_interface_files,
     type_description_tuples_from_interface_files
@@ -38,8 +37,6 @@ class GenerateC(GenerateCommandExtension):
         output_path,
         type_descriptions=None
     ):
-        generated_files = []
-
         package_share_path = \
             pathlib.Path(get_package_share_directory('rosidl_generator_c'))
         templates_path = package_share_path / 'resource'
@@ -65,19 +62,6 @@ class GenerateC(GenerateCommandExtension):
 
         type_description_tuples = type_description_tuples_from_interface_files(interface_files, output_path)
 
-        # Generate visibility control file
-        visibility_control_file_template_path = \
-            templates_path / 'rosidl_generator_c__visibility_control.h.in'
-        visibility_control_file_path = \
-            output_path / 'msg' / 'rosidl_generator_c__visibility_control.h'
-
-        generate_visibility_control_file(
-            package_name=package_name,
-            template_path=visibility_control_file_template_path,
-            output_path=visibility_control_file_path
-        )
-        generated_files.append(visibility_control_file_path)
-
         # Generate code
         with legacy_generator_arguments_file(
             package_name=package_name,
@@ -88,6 +72,4 @@ class GenerateC(GenerateCommandExtension):
             type_description_tuples=type_description_tuples,
             ros_interface_files=interface_files
         ) as path_to_arguments_file:
-            generated_files.extend(generate_c(path_to_arguments_file))
-
-        return generated_files
+            return generate_c(path_to_arguments_file)

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -33,17 +33,6 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   )
 endforeach()
 
-# generate header to switch between export and import for a specific package
-set(_visibility_control_file
-  "${_output_path}/msg/rosidl_generator_cpp__visibility_control.hpp")
-string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
-configure_file(
-  "${rosidl_generator_cpp_TEMPLATE_DIR}/rosidl_generator_cpp__visibility_control.hpp.in"
-  "${_visibility_control_file}"
-  @ONLY
-)
-list(APPEND _generated_headers "${_visibility_control_file}")
-
 set(_dependency_files "")
 set(_dependencies "")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -54,6 +54,31 @@ def get_newest_modification_time(target_dependencies):
             newest_timestamp = ts
     return newest_timestamp
 
+def render_visibility_control_file(package_name, template_path, base_output_path):
+    """
+    Render a visibility control file from a template.
+
+    :param package_name: Name of the ROS package for which
+      to generate the file.
+    :param template_path: Path to template visibility control file.
+      May contain @PROJECT_NAME@ and @PROJECT_NAME_UPPER@ placeholders,
+      to be substituted by the package name, accordingly.
+    :param base_output_path: Base output path for the generated file.
+
+    :returns: Path to the generated visibility control file.
+    """
+    with open(template_path, 'r') as fd:
+        content = fd.read()
+
+    content = content.replace('@PROJECT_NAME@', package_name)
+    content = content.replace('@PROJECT_NAME_UPPER@', package_name.upper())
+
+    # Use stem to remove the .in extension
+    output_path = pathlib.Path(base_output_path) / 'msg' / template_path.stem
+    with open(output_path, 'w') as fd:
+        fd.write(content)
+
+    return output_path
 
 def generate_files(
     generator_arguments_file, mapping, additional_context=None,
@@ -67,7 +92,17 @@ def generate_files(
             'Could not find template: ' + template_filename
 
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
-    generated_files = []
+
+    # Generate visibility control files if any
+    generated_files = \
+        [render_visibility_control_file(
+            args['package_name'],
+            template,
+            args['output_dir']
+        )
+            for template in template_basepath.iterdir()
+            if template.is_file() and 'visibility_control' in template.name
+        ]
 
     type_description_files = {}
     for description_tuple in args.get('type_description_tuples', []):

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -104,17 +104,6 @@ add_custom_command(
   VERBATIM
 )
 
-# generate header to switch between export and import for a specific package
-set(_visibility_control_file
-  "${_output_path}/msg/rosidl_typesupport_introspection_c__visibility_control.h")
-string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
-configure_file(
-  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/rosidl_typesupport_introspection_c__visibility_control.h.in"
-  "${_visibility_control_file}"
-  @ONLY
-)
-list(APPEND _generated_msg_header_files "${_visibility_control_file}")
-
 set(_target_suffix "__rosidl_typesupport_introspection_c")
 
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_introspection_c_LIBRARY_TYPE}

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
@@ -17,7 +17,7 @@ import pathlib
 from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.helpers import generate_visibility_control_file, legacy_generator_arguments_file, split_interface_files
+from rosidl_cli.command.helpers import legacy_generator_arguments_file, split_interface_files
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_introspection_c import generate_c
@@ -33,8 +33,6 @@ class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
         include_paths,
         output_path
     ):
-        generated_files = []
-
         package_share_path = pathlib.Path(
             get_package_share_directory('rosidl_typesupport_introspection_c'))
 
@@ -51,23 +49,6 @@ class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
                 output_path=output_path / 'tmp',
             ))
 
-        # Generate visibility control file
-        visibility_control_file_template_path = \
-            'rosidl_typesupport_introspection_c__visibility_control.h.in'
-        visibility_control_file_template_path = \
-            templates_path / visibility_control_file_template_path
-        visibility_control_file_path = \
-            'rosidl_typesupport_introspection_c__visibility_control.h'
-        visibility_control_file_path = \
-            output_path / 'msg' / visibility_control_file_path
-
-        generate_visibility_control_file(
-            package_name=package_name,
-            template_path=visibility_control_file_template_path,
-            output_path=visibility_control_file_path
-        )
-        generated_files.append(visibility_control_file_path)
-
         # Generate typesupport code
         with legacy_generator_arguments_file(
             package_name=package_name,
@@ -76,6 +57,4 @@ class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
             templates_path=templates_path,
             output_path=output_path
         ) as path_to_arguments_file:
-            generated_files.extend(generate_c(path_to_arguments_file))
-
-        return generated_files
+            return generate_c(path_to_arguments_file)


### PR DESCRIPTION
This patch moves the visibility control generation responsability to the `generate_files` base function instead of having to manually generate it in the `.cmake` or `cli.py` files.